### PR TITLE
Bio 330 star storage fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,8 +71,8 @@ COPY --from=bioinformatics_base ${star_dir}/source/STAR ${star_dir}/source/STAR
 #===========================#
 # Installing tools          #
 #===========================#
-RUN mkdir -p /scripts /resources /results
-RUN chmod ugo+wx /results
+RUN mkdir -p /scripts /resources /results /STAR_tmp
+RUN chmod ugo+wx /results /STAR_tmp
 COPY ERVmapping.sh /scripts
 COPY templates/ERValign.sh /scripts
 COPY templates/ERVcount.sh /scripts

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This option can only have 3 values: { `ALL`, `STAR`, `BED` }:
 * `BED` to only run the ERV quantification.
 
 
-### Optional parameters (recommended) 
+### <a id='optparam'></a>Optional parameters (*recommended*) 
 There are a few parameters that can be added to the ERVmap image to make the process more efficient.
 * `--cpus 20`: if you have a multi-core system (and you should have one), you can specify the number of CPUs to use (e.g. 20);
 * `--limit-ram 48000000000`: this limits the amount of RAM used to avoid overusing the resources 
@@ -66,23 +66,28 @@ There are also other parameters from Docker that should be included before `ervm
     --memory-swap 100G
 ``` 
 
+---
+
 # Nextflow version
 
 To run this pipeline using [Nextflow](https://www.nextflow.io/), simply run the following:
-`nextflow -C nextflow.config  run main.nf`
+`nextflow -C nextflow.config run main.nf`
 where `nextflow.config` include the minimum set of parameters to run ERVmap within the docker container. Specifically:
 ```
 params {
-    inputDir='' # external path of the input data
-    outputDir='' # external path of the output results
-    localOutDir='' # internal path of the results
-    outPrefix='test.' # [optional] it defines the prefix for the results
-    cpus=1 # Number of cpus/threads to use for the alignment          
-    limitMemory=32000000 # memory limit for samtools
+    genome='/path/to/genome' # external path to the indexed genome for the STAR aligner
+    inputDir='path/to/input/folder' # external path of the input data
+    outputDir='/path/to/output/folder' # external path of the output results
+    starTmpDir='/path/to/STAR/temp/folder' # external path of the STAR aligner temporary folder. REQUIRED
+    localOutDir='.' # internal path of the results
+    cpus=20 # Number of cpus/threads to use for the alignment 
+    limitMemory=1850861158 # memory limit for STAR
     debug='off' # either [on|off] 
 }
 ```
-**NOTE**: another critical parameter is the location of the indexed genome. This information must be included in the config as `containerOptions = '--memory 35G --memory-swap 100G -v /path/to/genome:/genome:ro'` (replace `/path/to/genome` with the external location of the genome)
+**NOTE:** Adjust the memory settings of the docker container if needed, but recall that STAR requires about 32G of RAM (see [Optional Parameters](#optparam)).
+
+**NOTE:** If you need to keep the BAM files generated, please make sure to make a copy. By default, the BAMs remains in the nextflow `work` folder and only symbolic links are available in `outputDir`. By cleaning up the `work` folder, e.g. by running `nextflow clean`, the bam files will be removed. The ERVmap results are copied into `outputDir` and thus are permanent.
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -75,14 +75,15 @@ To run this pipeline using [Nextflow](https://www.nextflow.io/), simply run the 
 where `nextflow.config` include the minimum set of parameters to run ERVmap within the docker container. Specifically:
 ```
 params {
-    genome='/path/to/genome' # external path to the indexed genome for the STAR aligner
-    inputDir='path/to/input/folder' # external path of the input data
-    outputDir='/path/to/output/folder' # external path of the output results
+    genome='/path/to/genome'               # external path to the indexed genome for the STAR aligner
+    inputDir='path/to/input/folder'        # external path of the input data
+    inputPattern="*{1,2}.fastq.gz"         # pattern to search for input FASTQ files
+    outputDir='/path/to/output/folder'     # external path of the output results
     starTmpDir='/path/to/STAR/temp/folder' # external path of the STAR aligner temporary folder. REQUIRED
-    localOutDir='.' # internal path of the results
-    cpus=20 # Number of cpus/threads to use for the alignment 
-    limitMemory=1850861158 # memory limit for STAR
-    debug='off' # either [on|off] 
+    localOutDir='.'                        # internal path of the results
+    cpus=20                                # Number of cpus/threads to use for the alignment 
+    limitMemory=1850861158                 # memory limit for STAR
+    debug='off'                            # either [on|off] 
 }
 ```
 **NOTE:** Adjust the memory settings of the docker container if needed, but recall that STAR requires about 32G of RAM (see [Optional Parameters](#optparam)).

--- a/main.nf
+++ b/main.nf
@@ -18,9 +18,6 @@ if (!params.starTmpDir) {
 if ( !new File(params.starTmpDir).exists()) {
     exit 1, 'The STAR temporary folder does not exists. ('+params.starTmpDir+')\n'
 }
-if (!params.outPrefix) {
-    exit 1, "Output prefix parameter is missing."
-}
 if (!params.localOutDir) {
     params.localOutDir='bam'
 }
@@ -53,8 +50,8 @@ process ERValign {
     val(debug) from params.debug
     
     output:
-    path ( "${localOutDir}/${outPrefix}Aligned.sortedByCoord.out.bam" ) into bam_ch
-    path ( "${localOutDir}/${outPrefix}Aligned.sortedByCoord.out.bam.bai" ) into bai_ch
+    path ( "${localOutDir}/${sample}.Aligned.sortedByCoord.out.bam" ) into bam_ch
+    path ( "${localOutDir}/${sample}.Aligned.sortedByCoord.out.bam.bai" ) into bai_ch
     val "${sample}" into prefix_ch
 
     shell:
@@ -83,7 +80,7 @@ process ERVcount {
     path (bai) from bai_ch
     
     output: 
-    path (params.outPrefix+'ERVresults.txt') into final_results_ch
+    path ( "${outPrefix}"+'.ERVresults.txt') into final_results_ch
 
     shell:
     template "ERVcount.sh"

--- a/main.nf
+++ b/main.nf
@@ -26,7 +26,7 @@ if (!params.debug) {
 }
 
 
-pairFiles_ch = Channel.fromFilePairs( params.inputDir+"/*{1,2}.fastq.gz", size: 2, checkIfExists: true )
+pairFiles_ch = Channel.fromFilePairs( params.inputDir+"/"+params.inputPattern, size: 2, checkIfExists: true )
 
 
 process ERValign {

--- a/main.nf
+++ b/main.nf
@@ -3,23 +3,31 @@
 
 // check parameters
 if (!params.inputDir) {
-    exit 1, "inputDir parameter is missing."
-}
-if (!params.outputDir) {
-    exit 1, "outputDir parameter is missing."
+    exit 1, 'inputDir parameter is missing.'
 }
 if ( !new File(params.inputDir).exists()) {
     exit 1, "The input folder does not exists."+params.inputDir+"\n"
 }
+if (!params.outputDir) {
+    exit 1, "outputDir parameter is missing."
+}
+if (!params.starTmpDir) {
+    exit 1, "starTmpDir parameter is missing."
+}
+
+if ( !new File(params.starTmpDir).exists()) {
+    exit 1, 'The STAR temporary folder does not exists. ('+params.starTmpDir+')\n'
+}
 if (!params.outPrefix) {
     exit 1, "Output prefix parameter is missing."
-}
-if (!params.debug) {
-    exit 1, "Debug prefix parameter is missing."
 }
 if (!params.localOutDir) {
     params.localOutDir='bam'
 }
+if (!params.debug) {
+    exit 1, "Debug prefix parameter is missing."
+}
+
 
 pairFiles_ch = Channel.fromFilePairs( params.inputDir+"/*{1,2}.fastq.gz", size: 2, checkIfExists: true )
 

--- a/main.nf
+++ b/main.nf
@@ -5,7 +5,7 @@
 if (!params.inputDir) {
     exit 1, 'inputDir parameter is missing.'
 }
-if ( !new File(params.inputDir).exists()) {
+if (!new File(params.inputDir).exists()) {
     exit 1, "The input folder does not exists."+params.inputDir+"\n"
 }
 if (!params.outputDir) {
@@ -15,11 +15,11 @@ if (!params.starTmpDir) {
     exit 1, "starTmpDir parameter is missing."
 }
 
-if ( !new File(params.starTmpDir).exists()) {
+if (!new File(params.starTmpDir).exists()) {
     exit 1, 'The STAR temporary folder does not exists. ('+params.starTmpDir+')\n'
 }
-if (!params.localOutDir) {
-    params.localOutDir='bam'
+if (!params.localOutputDir) {
+    params.localOutputDir='bam'
 }
 if (!params.debug) {
     exit 1, "Debug prefix parameter is missing."
@@ -34,7 +34,7 @@ process ERValign {
     
     // executor configuration
     time '8h'
-    memory '35.GB'
+    memory '35 GB'
     scratch true
     cpus params.cpus
     publishDir params.outputDir
@@ -44,15 +44,15 @@ process ERValign {
     errorStrategy 'terminate'
 
     input:
-    tuple val(sample), file(reads) from pairFiles_ch
-    val(localOutDir) from params.localOutDir
-    val(limitMemory) from params.limitMemory
-    val(debug) from params.debug
+    tuple val(sample), file (reads) from pairFiles_ch
+    val (localOutputDir) from params.localOutputDir
+    val (limitMemory) from params.limitMemory
+    val (debug) from params.debug
     
     output:
-    path ( "${localOutDir}/${sample}.Aligned.sortedByCoord.out.bam" ) into bam_ch
-    path ( "${localOutDir}/${sample}.Aligned.sortedByCoord.out.bam.bai" ) into bai_ch
-    val "${sample}" into prefix_ch
+    path ("${localOutputDir}/${sample}.Aligned.sortedByCoord.out.bam") into bam_ch
+    path ("${localOutputDir}/${sample}.Aligned.sortedByCoord.out.bam.bai") into bai_ch
+    val (sample) into prefix_ch
 
     shell:
     template 'ERValign.sh'
@@ -74,15 +74,15 @@ process ERVcount {
     
     input:
     val (sample) from prefix_ch
-    val(debug) from params.debug
+    val (debug) from params.debug
     path (bam) from bam_ch
     path (bai) from bai_ch
     
     output: 
-    path ( "${sample}"+'.ERVresults.txt') into final_results_ch
+    path ("${sample}"+'.ERVresults.txt') into final_results_ch
 
     shell:
-    template "ERVcount.sh"
+    template 'ERVcount.sh'
 }
 
 // ~~~~~~~~~~~~~~~ PIPELINE COMPLETION EVENTS ~~~~~~~~~~~~~~~~~~~ //

--- a/main.nf
+++ b/main.nf
@@ -73,13 +73,13 @@ process ERVcount {
     stageInMode 'symlink'
     
     input:
-    val (outPrefix) from prefix_ch
+    val (sample) from prefix_ch
     val(debug) from params.debug
     path (bam) from bam_ch
     path (bai) from bai_ch
     
     output: 
-    path ( "${outPrefix}"+'.ERVresults.txt') into final_results_ch
+    path ( "${sample}"+'.ERVresults.txt') into final_results_ch
 
     shell:
     template "ERVcount.sh"

--- a/main.nf
+++ b/main.nf
@@ -70,7 +70,6 @@ process ERVcount {
     // other configuration
     echo true
     errorStrategy 'terminate'
-    mode = 'BED'
     stageInMode 'symlink'
     
     input:

--- a/main.nf
+++ b/main.nf
@@ -34,7 +34,7 @@ process ERValign {
     
     // executor configuration
     time '8h'
-    // memory '35.GB'
+    memory '35.GB'
     scratch true
     cpus params.cpus
     publishDir params.outputDir

--- a/nextflow.config
+++ b/nextflow.config
@@ -9,19 +9,20 @@ docker {
 }
 
 params {
-    inputDir=''
-    outputDir=''
-    localOutDir=''
-    outPrefix='test.'
-    cpus=1
-    limitMemory=32000000
+    genome='/path/to/genome'
+    inputDir='path/to/input/folder'
+    outputDir='/path/to/output/folder'
+    starTmpDir='/path/to/STAR/temp/folder'
+    localOutDir='.'
+    cpus=3
+    limitMemory=1850861158
     debug='off'
 }
 
 process {
     withName: ERValign {
         container = 'eipm/ervmap:latest'
-        containerOptions = '--memory 35G --memory-swap 100G -v /path/to/genome:/genome:ro'
+        containerOptions = "--memory 35G --memory-swap 100G -v ${params.genome}:/genome:ro -v ${params.starTmpDir}:/STAR_tmp"
     }
 
     withName: ERVcount {

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,6 +11,7 @@ docker {
 params {
     genome='/path/to/genome'
     inputDir='path/to/input/folder'
+    inputPattern="*{1,2}.fastq.gz"
     outputDir='/path/to/output/folder'
     starTmpDir='/path/to/STAR/temp/folder'
     localOutDir='.'

--- a/templates/ERValign.sh
+++ b/templates/ERValign.sh
@@ -43,7 +43,7 @@ if [ -z ${LIMIT_RAM+x} ];then export LIMIT_RAM=35129075129;fi
 
 logMsg "DEBUG" "OUT_PREFIX:($OUT_PREFIX)"
 logMsg "DEBUG" "Local OutDir: $(pwd)/$LOCAL_OUTDIR"
-logMsg "DEBUG" "Reads: ($READS)"l
+logMsg "DEBUG" "Reads: ($READS)"
 logMsg "DEBUG" "CPUs:($CPUS)"
 logMsg "DEBUG" "Limit RAM:($LIMIT_RAM)"
 

--- a/templates/ERValign.sh
+++ b/templates/ERValign.sh
@@ -29,7 +29,7 @@ READS="!{reads}"
 CPUS=!{task.cpus}
 LIMIT_RAM=!{limitMemory}
 OUT_PREFIX="!{sample}."
-LOCAL_OUTDIR="!{localOutDir}"
+LOCAL_OUTDIR="!{localOutputDir}"
 
 # checking the prefix of the output BAM
 if [ -z ${OUT_PREFIX+x} ];then

--- a/templates/ERValign.sh
+++ b/templates/ERValign.sh
@@ -24,10 +24,6 @@ logMsg() {
     fi
 } 
 
-function usage() {
-    echo "Usage: ERValign.sh <-r1|--read1> SAMPLE_1.fastq.gz <-r2|--read2> SAMPLE_1.fastq.gz [-o|--output] results/SAMPLE [-c|--cpus] Ncpus [-l|--limit-ram] 35129075129 [-d|--debug {off|on}]\nA genome folder should be present in /genome"
-}
-
 # initializing parameters for STAR
 READS="!{reads}"
 CPUS=!{task.cpus}
@@ -55,7 +51,7 @@ logMsg "INFO" "-------- START ERValign ---------"
 BAM="$LOCAL_OUTDIR/$OUT_PREFIX""Aligned.sortedByCoord.out.bam"
 
 logMsg "INFO" "---- Alignment ----"
-STAR --genomeDir /genome --runThreadN $CPUS --outSAMtype BAM SortedByCoordinate --limitBAMsortRAM $LIMIT_RAM --outFilterMultimapNmax 1 --outFilterMismatchNmax 999 --outFilterMismatchNoverLmax 0.02 --alignIntronMin 20 --alignIntronMax 1000000 --alignMatesGapMax 1000000 --readFilesIn $READS --readFilesCommand zcat --outFileNamePrefix $LOCAL_OUTDIR/$OUT_PREFIX
+STAR --genomeDir /genome --runThreadN $CPUS --outSAMtype BAM SortedByCoordinate --limitBAMsortRAM $LIMIT_RAM --outFilterMultimapNmax 1 --outFilterMismatchNmax 999 --outFilterMismatchNoverLmax 0.02 --alignIntronMin 20 --alignIntronMax 1000000 --alignMatesGapMax 1000000 --readFilesIn $READS --readFilesCommand zcat --outFileNamePrefix $LOCAL_OUTDIR/$OUT_PREFIX --outTmpDir /STAR_tmp
 [ $? == 0 ] || logMsg  "ERROR" "The alignment didn't complete succesfully. Check the logs."
 
 logMsg "INFO" "---- Alignment Complete ----"

--- a/templates/ERValign.sh
+++ b/templates/ERValign.sh
@@ -51,7 +51,7 @@ logMsg "INFO" "-------- START ERValign ---------"
 BAM="$LOCAL_OUTDIR/$OUT_PREFIX""Aligned.sortedByCoord.out.bam"
 
 logMsg "INFO" "---- Alignment ----"
-STAR --genomeDir /genome --runThreadN $CPUS --outSAMtype BAM SortedByCoordinate --limitBAMsortRAM $LIMIT_RAM --outFilterMultimapNmax 1 --outFilterMismatchNmax 999 --outFilterMismatchNoverLmax 0.02 --alignIntronMin 20 --alignIntronMax 1000000 --alignMatesGapMax 1000000 --readFilesIn $READS --readFilesCommand zcat --outFileNamePrefix $LOCAL_OUTDIR/$OUT_PREFIX --outTmpDir /STAR_tmp
+STAR --genomeDir /genome --runThreadN $CPUS --outSAMtype BAM SortedByCoordinate --limitBAMsortRAM $LIMIT_RAM --outFilterMultimapNmax 1 --outFilterMismatchNmax 999 --outFilterMismatchNoverLmax 0.02 --alignIntronMin 20 --alignIntronMax 1000000 --alignMatesGapMax 1000000 --readFilesIn $READS --readFilesCommand zcat --outFileNamePrefix $LOCAL_OUTDIR/$OUT_PREFIX --outTmpDir /STAR_tmp/$OUT_PREFIX""tmp
 [ $? == 0 ] || logMsg  "ERROR" "The alignment didn't complete succesfully. Check the logs."
 
 logMsg "INFO" "---- Alignment Complete ----"

--- a/templates/ERValign.sh
+++ b/templates/ERValign.sh
@@ -28,7 +28,7 @@ logMsg() {
 READS="!{reads}"
 CPUS=!{task.cpus}
 LIMIT_RAM=!{limitMemory}
-OUT_PREFIX="!{outPrefix}"
+OUT_PREFIX="!{sample}."
 LOCAL_OUTDIR="!{localOutDir}"
 
 # checking the prefix of the output BAM
@@ -42,6 +42,7 @@ if [ -z ${LIMIT_RAM+x} ];then export LIMIT_RAM=35129075129;fi
 [ -e "/genome/genomeParameters.txt" ] || logMsg "ERROR" "The indexed genome cannot be found. Check that it is present and you have read permissions."
 
 logMsg "DEBUG" "OUT_PREFIX:($OUT_PREFIX)"
+logMsg "DEBUG" "Local OutDir: $(pwd)/$LOCAL_OUTDIR"
 logMsg "DEBUG" "Reads: ($READS)"l
 logMsg "DEBUG" "CPUs:($CPUS)"
 logMsg "DEBUG" "Limit RAM:($LIMIT_RAM)"

--- a/templates/ERVcount.sh
+++ b/templates/ERVcount.sh
@@ -24,7 +24,7 @@ logMsg() {
     fi
 }  
 
-OUT_PREFIX="!{outPrefix}."
+OUT_PREFIX="!{sample}."
 if [ -z ${OUT_PREFIX+x} ];then
     OUT_PREFIX="$RANDOM""_"
     logMsg "WARN" "This prefix will be used as output: $OUT_PREFIX"

--- a/templates/ERVcount.sh
+++ b/templates/ERVcount.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-function usage() {
-    echo "Usage: ERVcount.sh <-b|--bam> Aligned.bam [-o|--output] results/SAMPLE [-d|--debug {off|on}]"
-}
-
 BAM="!{bam}"
 _DEBUG="!{debug}"
 
@@ -28,7 +24,7 @@ logMsg() {
     fi
 }  
 
-OUT_PREFIX=!{outPrefix}
+OUT_PREFIX="!{outPrefix}."
 if [ -z ${OUT_PREFIX+x} ];then
     OUT_PREFIX="$RANDOM""_"
     logMsg "WARN" "This prefix will be used as output: $OUT_PREFIX"


### PR DESCRIPTION
STAR requires a lot of RAM as well as disk space to align reads efficiently. This version allows to mount its temporary folder on the host, so that we overcome the limitation of docker space.